### PR TITLE
Tiny modifications to make installation slightly more proper on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ tmp/
 
 # no libraries
 *.lib
-lib/fltk-1.3.4
+lib/*
+!lib/fltk-1.3.4.zip
 
 # no IDE files
 *.sdf

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,13 +39,13 @@ unzip fltk-1.3.4.zip
 cd fltk-1.3.4
 
 chmod +x configure
-./configure --with-abiversion=10304
-sudo make
-sudo make install
-cp lib/*.a ..
+./configure --prefix="$PWD/.." --with-abiversion=10304
+make
+make install
 
 cd ../..
 
+export PATH="$PWD/lib/bin:$PATH"
 make
 sudo make install
 ```

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ PROGNAME = Polished Map
 BINNAME = polishedmap
 DEBUGBINNAME = polishedmapd
 
+DESTDIR =
+TARGET_PREFIX = /usr/local
+TARGET_BINDIR = $(TARGET_PREFIX)/bin
+TARGET_DATADIR = $(TARGET_PREFIX)/share
+
 CXX = g++
 LD = $(CXX)
 RM = rm -rf
@@ -13,8 +18,8 @@ DEBUGOBJDIR = tmp/debug
 LIBDIR = lib
 BINDIR = bin
 
-CXXFLAGS = -std=c++11 -I include -I /usr/include -I$(SRCDIR) -I$(RESDIR)
-LDFLAGS = $(wildcard $(LIBDIR)/*.a) -lm -lpng -lz -lXfixes -lXext -lXft -lfontconfig -lXinerama -lpthread -ldl -lX11 -lXpm -lXrender
+CXXFLAGS = -std=c++11 -I$(SRCDIR) -I$(RESDIR) $(shell fltk-config --use-images --cxxflags)
+LDFLAGS = $(shell fltk-config --use-images --ldflags) $(shell pkg-config --libs libpng16 xpm)
 
 RELEASEFLAGS = -DNDEBUG -O3 -flto -march=native
 DEBUGFLAGS = -DDEBUG -D_DEBUG -O0 -g -ggdb3 -Wall -Wextra -pedantic -Wno-unknown-pragmas -Wno-sign-compare
@@ -61,6 +66,6 @@ clean:
 	$(RM) $(TARGET) $(DEBUGTARGET) $(OBJECTS) $(DEBUGOBJECTS)
 
 install: release
-	cp $(TARGET) /usr/local/bin/$(BINNAME)
-	cp $(RESDIR)/app.xpm /usr/share/pixmaps/polishedmap48.xpm
-	cp $(RESDIR)/app-icon.xpm /usr/share/pixmaps/polishedmap16.xpm
+	cp $(TARGET) $(DESTDIR)$(TARGET_BINDIR)/$(BINNAME)
+	cp $(RESDIR)/app.xpm $(DESTDIR)$(TARGET_DATADIR)/pixmaps/polishedmap48.xpm
+	cp $(RESDIR)/app-icon.xpm $(DESTDIR)$(TARGET_DATADIR)/pixmaps/polishedmap16.xpm


### PR DESCRIPTION
This allows a user to choose to use the system's FLTK library, and uses the system headers for libpng and others as well.
Adapted INSTALL.md to allow for this change to happen.

Also made the Makefile slightly more packager-friendly.